### PR TITLE
Database clean up and seed alterations

### DIFF
--- a/db/20171126_seeds.rb
+++ b/db/20171126_seeds.rb
@@ -32,7 +32,9 @@ module WorkForwardNola
         problems for clients, provide assistance with computer hardware and 
         software.',
         experienced_range: '$25,000 - $35,000',
-        entry_wage: '$14.42'
+        entry_wage: '$14.42',
+        career_image: 'help_desk.jpg',
+        alt_title: 'Person is wearing a headset and looking at a computer'
       ['Problem solver',
       ].each do |trait|
         help_desk.add_trait all_traits[trait]

--- a/db/migrations/009_drop_experiencedwage_column_from_careers.rb
+++ b/db/migrations/009_drop_experiencedwage_column_from_careers.rb
@@ -7,7 +7,7 @@ Sequel.migration do
 
   down do
     alter_table(:careers) do
-      add_column :experienced_wage, Float, null: false, default: false
+      add_column :experienced_wage, Float, null: false, default: 0.0
     end
   end
 end


### PR DESCRIPTION
#42 
Did two things: added in seeds for career_image and alt_title and fixed a bug where rake:db reset would complain about experienced wage. Experienced wage was being considered as a boolean instead of a float so it would not properly drop the column/reset. 