### PR TITLE
Fixed a bug/issue with SMTP from AWS

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -189,6 +189,7 @@ module WorkForwardNola
 
       Pony.mail(
         to: body['recipient'],
+        from: ENV['SENDER_EMAIL'], #AWS complains in a dev environment if you don't provide a from address.
         subject: 'Your NOLA Career Results',
         html_body: email_body,
         via: :smtp,


### PR DESCRIPTION
added in a line for the Pony gem config to be configured to send using AWS SMTP during dev - ideally, it won't matter for production (when SES should be uncapped) but it makes things less buggy and easier to work with when it isn't complaining your email isn't verified.